### PR TITLE
Z Bias changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ npctransport.pb.h
 npctransport_pb2.py
 pyext/#swig.i-in#
 .DS_Store
+.vscode/

--- a/data/npctransport.proto
+++ b/data/npctransport.proto
@@ -54,15 +54,17 @@ message Configuration {
     required FloatRange interaction_k_factor=7;
     required FloatRange interaction_range_factor=8;
     optional string type=9; // type name, e.g. "kap121"
-    optional FloatRange k_z_bias=10; // if non-0, add a biasing constant force pulling to lower (k>0) or higher (k<0)
+    optional FloatRange k_z_bias=10; // if non-zero, add a biasing constant force pulling towards z=k_z_bias_z (k>0) or away from z=k_z_bias_z (k<0)
     optional FloatRange k_z_bias_fraction=11; // fraction of particles that will get the z-bias, meaningful if in (0,1]
-    optional double site_relative_distance=12 [default=1.0]; // distance of sites from center relative to particle radius
-    optional double site_radius=13 [default=0.0]; // radius around site within which maximal interaction energy is felt
-    optional int32 beads_tail_n=14 [default=0]; // NOT IMPLEMENTED - option for a tail of beads, 0 for none
-    optional double beads_tail_radius=15 [default=0]; // NOT IMPLEMENTED - radius of tail beads
-    optional double beads_tail_k=16 [default=1.0]; // NOT IMPLEMENTED - k for tail springs;
-    optional double beads_tail_bond_length=17 [default=1.0]; // NOT IMPLEMENTED - length of bond between beads
-    repeated XYZ site_coordinates=18; // coordinates of interaction sites relative to sphere center, valid if length is zero or equals to interactions field. Overrides site_relative distance
+    optional FloatRange k_z_bias_z=12; // z coordinate to bias towards/away from (default=0) (relevant only if k_z_bias is non-zero)
+    optional IntRange k_z_bias_max_t_ns=13; // minimal time point in nanoseconds to stop the z-bias. Biasing stops only after first simulation restart that takes place after the specified time. (default - never stop; relevant only if k_z_bias is non-zero)
+    optional double site_relative_distance=14 [default=1.0]; // distance of sites from center relative to particle radius
+    optional double site_radius=15 [default=0.0]; // radius around site within which maximal interaction energy is felt
+    optional int32 beads_tail_n=16 [default=0]; // NOT IMPLEMENTED - option for a tail of beads, 0 for none
+    optional double beads_tail_radius=17 [default=0]; // NOT IMPLEMENTED - radius of tail beads
+    optional double beads_tail_k=18 [default=1.0]; // NOT IMPLEMENTED - k for tail springs;
+    optional double beads_tail_bond_length=19 [default=1.0]; // NOT IMPLEMENTED - length of bond between beads
+    repeated XYZ site_coordinates=20; // coordinates of interaction sites relative to sphere center, valid if length is zero or equals to interactions field. Overrides site_relative distance
   };
   message ObstacleConfiguration {
     repeated XYZ xyzs=1; // center of mass of each such obstacle (also sets the number)
@@ -182,6 +184,7 @@ message Assignment {
     repeated string type_suffix_list=19; // list of suffixes appended to the end of the type field in corresponding chain particles. The list length is, assumed to be either 0 (=ignore) or the number of chain particles. Set to "" for particles that should not be modified. This enables customization of the interaction properties of different chain particles. Note that 'interaction_k_factor', 'interaction_range_factor', 'd_factor', 'interactions' fields are all ignored for particles whose suffix is not "".
     optional double backbone_k_factor=20 [default=1.0]; // FOR NOW - does nothing!!!!!
   };
+  // See FloaterConfiguration for documentation
   message FloaterAssignment {
     required IntAssignment number=1;
     required FloatAssignment radius=2;
@@ -190,15 +193,17 @@ message Assignment {
     required FloatAssignment interaction_k_factor=5;
     required FloatAssignment interaction_range_factor=7;
     optional string type=8; // e.g., "kap121"
-    optional FloatAssignment k_z_bias=9; // if non-0, add a biasing constant force pulling to lower (k>0) or higher (k<0)
-    optional FloatAssignment k_z_bias_fraction=11; // fraction of particles that will get the z-bias, meaningful if in (0,1]
-    optional double site_relative_distance=12 [default=1.0]; // distance of sites from center relative to particle radius
-    optional double site_radius=13 [default=0.0]; // radius around site at which maximal interaction is felt
-    optional int32 beads_tail_n=14 [default=0]; // option for a tail of beads, 0 for none
-    optional double beads_tail_radius=15 [default=0]; // radius of tail beads
-    optional double beads_tail_k=16 [default=1.0]; // k for tail springs;
-    optional double beads_tail_bond_length=17 [default=1.0]; // length of bond between beads
-    repeated XYZ site_coordinates=18; // coordinates of interaction sites relative to sphere center, valid if length is zero or equals to interactions field. If specified, overrides site_relative_distance
+    optional FloatAssignment k_z_bias=9; 
+    optional FloatAssignment k_z_bias_fraction=10;
+    optional FloatAssignment k_z_bias_z=11; 
+    optional IntAssignment k_z_bias_max_t_ns=12; 
+    optional double site_relative_distance=13 [default=1.0]; // distance of sites from center relative to particle radius
+    optional double site_radius=14 [default=0.0]; // radius around site at which maximal interaction is felt
+    optional int32 beads_tail_n=15 [default=0]; // option for a tail of beads, 0 for none
+    optional double beads_tail_radius=16 [default=0]; // radius of tail beads
+    optional double beads_tail_k=17 [default=1.0]; // k for tail springs;
+    optional double beads_tail_bond_length=18 [default=1.0]; // length of bond between beads
+    repeated XYZ site_coordinates=19; // coordinates of interaction sites relative to sphere center, valid if length is zero or equals to interactions field. If specified, overrides site_relative_distance
 
   };
   message ObstacleAssignment {

--- a/include/Scoring.h
+++ b/include/Scoring.h
@@ -624,11 +624,12 @@ class IMPNPCTRANSPORTEXPORT Scoring: public Object
 
      @param ps container for the particles to be biased
      @param k force constant
+     @param z z coordinate to bias towards/away from (relevant only if k_z_bias is non-zero)
 
      \see get_z_bias_restraints()
      \see get_scoring_function()
   */
-  void add_z_bias_restraint(SingletonContainerAdaptor ps, double k);
+  void add_z_bias_restraint(SingletonContainerAdaptor ps, double k, double z);
 
   /**
      adds a biasing potential for particle p towards z, to the restraints
@@ -638,8 +639,9 @@ class IMPNPCTRANSPORTEXPORT Scoring: public Object
 
      @param p the particle to be biased
      @param k force constant
+     @param z z coordinate to bias towards/away from (relevant only if k_z_bias is non-zero)
   */
-  void add_z_bias_restraint(Particle* p, double k);
+  void add_z_bias_restraint(Particle* p, double k, double z);
 
   /**
      return z_bias restraints for all particles that were added using
@@ -654,9 +656,11 @@ class IMPNPCTRANSPORTEXPORT Scoring: public Object
 
       @param ps the particles container
       @param k force constant for biasing ps
+      @param z z coordinate to bias towards/away from (relevant only if k_z_bias is non-zero)
   */
   IMP::Restraint* create_z_bias_restraint(SingletonContainerAdaptor ps,
-                                          double k) const;
+                                          double k,
+                                          double z) const;
 
   void add_custom_restraint(IMP::Restraint* r)
   { custom_restraints_.push_back(r); }

--- a/include/ZBiasSingletonScore.h
+++ b/include/ZBiasSingletonScore.h
@@ -14,6 +14,7 @@
 #include <IMP/singleton_macros.h>
 #include <IMP/algebra/Vector3D.h>
 #include <limits>
+#include <utility>
 
 IMPNPCTRANSPORT_BEGIN_NAMESPACE
 
@@ -22,58 +23,76 @@ IMPNPCTRANSPORT_BEGIN_NAMESPACE
 class IMPNPCTRANSPORTEXPORT ZBiasSingletonScore
     : public SingletonScore {
  private:
-  algebra::Vector3D v_deriv_; // deriv of force, which is of form (0,0,k)
-  double max_r2_; // maximal square r (distance from origin on x,y plane)
+  double k_; // force constant (positive for pulling towards z_, negative for pushing away from z_)
+  double max_r2_; // maximal square r (distance from z axis)
+  double z_; // z to bias towards/away from
  public:
   /**
      Exclude particles from the range of z coordinates [bottom_..top_]
      with repulsive force constant k
 
-     @param k repulsive force constant
-     @param max_r maximal distance from origin on x,y plane (radius
+     @param k force constant (positive for pulling towards z, negative for pushing away from z)
+     @param max_r maximal distance from z axis (radius
                   relative to pore axis) in which force is applied.
                   if 0.0, no limitation
+     @param z z of xy plane to bias towards / against (relevant only if k is non-zero)
    */
  ZBiasSingletonScore
    ( double k,
-     double max_r = HALF_SQRT_MAX_DOUBLE) // half for numerical margin error
-   : max_r2_( max_r * max_r )
-    {
-      set_k(k);
+     double max_r = HALF_SQRT_MAX_DOUBLE, // half for numerical margin error
+     double z = std::numeric_limits<double>::min())
+   : k_(k), max_r2_( max_r * max_r ), z_(z) {}
+
+
+  /**
+      returns the force constant for pulling
+  */
+  double get_k() const { return k_; }
+
+  /**
+      evaluates the derivative accoridng to the particle position
+
+      @param d core::XYZR position of the particle
+      @return a pair with the score and the derivative vector
+  */
+  std::pair<double, algebra::Vector3D>  eval_deriv(const core::XYZR &d) const {
+    double score;
+    algebra::Vector3D v_deriv;
+    double r2 =  std::pow(d.get_x(), 2) + std::pow(d.get_y(), 2);
+    if (r2 > max_r2_ && max_r2_ > 0.0) {
+      score = 0.0; 
+      v_deriv = algebra::Vector3D(0, 0, 0); // nothing to add to derivatives( = 0);
+      return std::make_pair(score, v_deriv);
     }
 
+    double dz = d.get_z() - z_;
+    if (dz  > 1e-6) {
+      score = k_ * dz;
+      v_deriv = algebra::Vector3D(0, 0, k_);
+    }
+    else if (dz < -1e-6) {
+      score = k_ * (-dz);
+      v_deriv = algebra::Vector3D(0, 0, -k_);
+    }
+    else{
+      score = 0;
+      v_deriv = algebra::Vector3D(0, 0, 0);
+    }
 
-  /**
-      returns the force constant for pulling to high z
-      (negative = pull to low z)
-  */
-  double get_k() const { return v_deriv_[2]; }
-
-  /**
-      sets the force constant for pulling to high z
-      (negative = pull to low z)
-
-      @param k force constant
-  */
-  void set_k(double k) {
-    v_deriv_ =  algebra::Vector3D(0, 0, k);
+    return std::make_pair(score, v_deriv);
   }
 
   virtual double evaluate_index(Model *m, ParticleIndex pi,
                                 DerivativeAccumulator *da) const override
   {
     core::XYZR d(m,pi);
-    double r2 =  std::pow(d.get_x(), 2) + std::pow(d.get_y(), 2);
-    if (r2 > max_r2_) {
-      // nothing to add to derivatives( = 0);
-      return 0.0; // TODO: this is not smooth around pore edge - problem
-    }
-    double const& k = v_deriv_[2];
-    double score = k * d.get_z();
+    auto score_deriv = eval_deriv(d);
+    auto score = score_deriv.first;
+    auto v_deriv = score_deriv.second;
     if (da) {
       IMP_LOG(VERBOSE, "result in " << score
-              << " and " << v_deriv_ << std::endl);
-      d.add_to_derivatives(v_deriv_, *da);
+              << " and " << v_deriv << std::endl);
+      d.add_to_derivatives(v_deriv, *da);
     }
     return score;
   }

--- a/include/ZBiasSingletonScore.h
+++ b/include/ZBiasSingletonScore.h
@@ -55,7 +55,7 @@ class IMPNPCTRANSPORTEXPORT ZBiasSingletonScore
       @param d core::XYZR position of the particle
       @return a pair with the score and the derivative vector
   */
-  std::pair<double, algebra::Vector3D>  eval_deriv(const core::XYZR &d) const {
+  std::pair<double, algebra::Vector3D>  evaluate_deriv(const core::XYZR &d) const {
     double score;
     algebra::Vector3D v_deriv;
     double r2 =  std::pow(d.get_x(), 2) + std::pow(d.get_y(), 2);
@@ -86,7 +86,7 @@ class IMPNPCTRANSPORTEXPORT ZBiasSingletonScore
                                 DerivativeAccumulator *da) const override
   {
     core::XYZR d(m,pi);
-    auto score_deriv = eval_deriv(d);
+    auto score_deriv = evaluate_deriv(d);
     auto score = score_deriv.first;
     auto v_deriv = score_deriv.second;
     if (da) {

--- a/src/Scoring.cpp
+++ b/src/Scoring.cpp
@@ -745,17 +745,17 @@ Restraint * Scoring::create_slab_restraint
 }
 
 void Scoring::add_z_bias_restraint
-( SingletonContainerAdaptor ps, double k )
+( SingletonContainerAdaptor ps, double k, double z)
 {
   ps.set_name_if_default("AddZBiasRestraintInput%1%");
   z_bias_restraints_.push_back
-    ( create_z_bias_restraint( ps, k) );
+    ( create_z_bias_restraint(ps, k, z) );
 }
 
-void Scoring::add_z_bias_restraint(Particle* p, double k)
+void Scoring::add_z_bias_restraint(Particle* p, double k, double z)
 {
   ParticlesTemp ps(1, p);
-  add_z_bias_restraint(ps, k);
+  add_z_bias_restraint(ps, k, z);
 }
 
 IMP::Restraints
@@ -765,7 +765,7 @@ Scoring::get_z_bias_restraints()
 }
 
 IMP::Restraint*
-Scoring::create_z_bias_restraint(SingletonContainerAdaptor ps, double k)
+Scoring::create_z_bias_restraint(SingletonContainerAdaptor ps, double k, double z)
 const
 {
   ps.set_name_if_default("CreateZBiasRestraintKInput%1%");
@@ -774,7 +774,7 @@ const
   if (get_sd()->get_has_slab()) {
     R = get_sd()->get_pore_radius(); // TODO: incompatible with dynamic pore radius
   }
-  IMP_NEW(ZBiasSingletonScore, zbsc, (k, R) );
+  IMP_NEW(ZBiasSingletonScore, zbsc, (k, R, z) );
   return
     container::create_restraint(zbsc.get(),
                                 ps.get(),

--- a/src/SimulationData.cpp
+++ b/src/SimulationData.cpp
@@ -501,7 +501,9 @@ void SimulationData::create_floaters
       ( type, f_data.interaction_k_factor().value());
 
   // add z-biasing potential for fraction of particles
-  if(f_data.has_k_z_bias()) if (f_data.k_z_bias().value() != 0)
+  bool has_k_z_bias = (f_data.has_k_z_bias()) && (f_data.k_z_bias().value() != 0);
+  bool k_z_time_valid = (!f_data.has_k_z_bias_max_t_ns()) || (f_data.k_z_bias_max_t_ns().value() > initial_simulation_time_ns_);
+  if(has_k_z_bias && k_z_time_valid)
     {
       double k = f_data.k_z_bias().value();
       unsigned int n_bias = f_data.number().value();
@@ -519,7 +521,17 @@ void SimulationData::create_floaters
       IMP_LOG(VERBOSE, "Biasing " << n_bias << " floaters"
                 << " of type " << type
                 << std::endl);
-      get_scoring()->add_z_bias_restraint(ps, k);
+                
+      double z;
+      unsigned int max_t;
+      if (f_data.has_k_z_bias_z()){
+        z = f_data.k_z_bias_z().value();
+      }
+      else {
+        z = std::numeric_limits<double>::min(); // default
+      }
+      
+      get_scoring()->add_z_bias_restraint(ps, k, z);
     }
 }
 

--- a/test/test_z_bias_score.py
+++ b/test/test_z_bias_score.py
@@ -5,42 +5,135 @@ import math
 import IMP.display
 import random
 
-radius=1
-bottom = -5
-top = 5
-k = 10.0
-boxw= top * 4
+def optimize_particle_z_bias(particle_radius, z_bias_k, z_bias_z, z_bias_max_r, boxw, particle_init_coords, n_optimizations=100, verbose=False):
+    # setup model
+    m = IMP.Model()
+    p = IMP.Particle(m)
+    d = IMP.core.XYZR.setup_particle(p)
+    d.set_coordinates_are_optimized(True)
+    d.set_radius(particle_radius)
+    bb = IMP.algebra.BoundingBox3D(IMP.algebra.Vector3D(-boxw, -boxw, -boxw),
+                                    IMP.algebra.Vector3D(boxw, boxw, boxw))
+    zbss = IMP.npctransport.ZBiasSingletonScore(z_bias_k, z_bias_max_r, z_bias_z)
+    sr = IMP.core.SingletonRestraint(m, zbss, p.get_index(), "zbias")
+    d.set_coordinates(particle_init_coords)
+    cg = IMP.core.SteepestDescent(m)
+    cg.set_scoring_function(sr)
+    cg.set_log_level(IMP.VERBOSE)
+    for _ in range(n_optimizations):
+        score = cg.optimize(3)
+        if verbose:
+            print (d.get_coordinates(), score)
+    return d.get_x(), d.get_y(), d.get_z()
 
-class ZBiasTests(IMP.test.TestCase):
-    def test_z_bias_(self):
-        """Check z-axis bias singleton score"""
-        # setup model
-        m= IMP.Model()
-        p= IMP.Particle(m)
-        d= IMP.core.XYZR.setup_particle(p)
-        d.set_coordinates_are_optimized(True)
-        d.set_radius(radius)
-        bb= IMP.algebra.BoundingBox3D(IMP.algebra.Vector3D(-boxw, -boxw, -boxw),
-                                      IMP.algebra.Vector3D(boxw, boxw, boxw))
-        zbss= \
-            IMP.npctransport.ZBiasSingletonScore(k)
-        sr= IMP.core.SingletonRestraint(m, zbss, p.get_index(), "zbias")
 
-        # position d randonmly within excluded zrange
-        d.set_coordinates([1,1,100])
-        print("BEFORE=", d.get_coordinates())
-        # steep descent out of excluded zone (hopefully)
-        cg= IMP.core.SteepestDescent(m)
-        cg.set_scoring_function(sr)
-        cg.set_log_level(IMP.VERBOSE)
-        for i in range(0,10000):
-            s=cg.optimize(3)
-#            print d.get_coordinates(), s
-            if s <= 0:
-                break
-        print("AFTER=", d.get_coordinates(), "Score =", s)
-        self.assertTrue(d.get_z() <= 0.01 and
-                        d.get_x() == 1 and
-                        d.get_y() == 1)
+class ZBiasTests(IMP.test.TestCase): 
+    def test_z_bias_1(self):
+        """Check z-axis bias singleton score - particle hovers around z=0 (from top)"""
+        
+        # setup parameters
+        particle_radius=1
+        z_bias_k = 10.0
+        z_bias_z = 0
+        z_bias_max_r = 1000.0
+        boxw= 20
+        particle_init_coords = [1, 1, 15]
+        
+        x, y, z = optimize_particle_z_bias(particle_radius, z_bias_k, z_bias_z, z_bias_max_r, boxw, particle_init_coords)
+        self.assertTrue((z - z_bias_z) <= 0.1 and
+                        (z - z_bias_z) >= -0.1 and
+                        x == particle_init_coords[0] and
+                        y == particle_init_coords[1])
+        
+    def test_z_bias_2(self):
+        """Check z-axis bias singleton score - particle hovers around z=0 (from bottom)"""
+        
+        # setup parameters
+        particle_radius=1
+        z_bias_k = 10.0
+        z_bias_z = 0
+        z_bias_max_r = 1000.0
+        boxw= 20
+        particle_init_coords = [1, 1, -15]
+        
+        x, y, z = optimize_particle_z_bias(particle_radius, z_bias_k, z_bias_z, z_bias_max_r, boxw, particle_init_coords)
+        self.assertTrue((z - z_bias_z) <= 0.1 and
+                        (z - z_bias_z) >= -0.1 and
+                        x == particle_init_coords[0] and
+                        y == particle_init_coords[1])
+        
+    def test_z_bias_3(self):
+        """Check z-axis bias singleton score - particle hovers around z=3 (from top)"""
+        
+        # setup parameters
+        particle_radius=1
+        z_bias_k = 10.0
+        z_bias_z = 3
+        z_bias_max_r = 1000.0
+        boxw= 20
+        particle_init_coords = [1, 1, 15]
+        
+        x, y, z = optimize_particle_z_bias(particle_radius, z_bias_k, z_bias_z, z_bias_max_r, boxw, particle_init_coords)
+        self.assertTrue((z - z_bias_z) <= 0.1 and
+                        (z - z_bias_z) >= -0.1 and
+                        x == particle_init_coords[0] and
+                        y == particle_init_coords[1])
+        
+    def test_z_bias_4(self):
+        """Check z-axis bias singleton score - particle hovers around z=3 (from bottom)"""
+        
+        # setup parameters
+        particle_radius=1
+        z_bias_k = 10.0
+        z_bias_z = 3
+        z_bias_max_r = 1000.0
+        boxw= 20
+        particle_init_coords = [1, 1, -15]
+        
+        x, y, z = optimize_particle_z_bias(particle_radius, z_bias_k, z_bias_z, z_bias_max_r, boxw, particle_init_coords)
+        self.assertTrue((z - z_bias_z) <= 0.1 and
+                        (z - z_bias_z) >= -0.1 and
+                        x == particle_init_coords[0] and
+                        y == particle_init_coords[1])
+        
+    def test_z_bias_5(self):
+        """Check z-axis bias singleton score - lower k slower convergence than higher k"""
+        
+        # setup parameters
+        particle_radius=1
+        z_bias_k_1 = 0.1
+        z_bias_k_2 = 10.0
+        z_bias_z = 0
+        z_bias_max_r = 1000.0
+        boxw= 20
+        particle_init_coords = [1, 1, 15]
+        
+        x1, y1, z1 = optimize_particle_z_bias(particle_radius, z_bias_k_1, z_bias_z, z_bias_max_r, boxw, particle_init_coords)
+        x2, y2, z2 = optimize_particle_z_bias(particle_radius, z_bias_k_2, z_bias_z, z_bias_max_r, boxw, particle_init_coords)
+        self.assertFalse((z1 - z_bias_z) <= 0.1 and
+                        (z1 - z_bias_z) >= -0.1)
+        self.assertTrue((z2 - z_bias_z) <= 0.1 and
+                        (z2 - z_bias_z) >= -0.1 and
+                        x2 == particle_init_coords[0] and
+                        y2 == particle_init_coords[1] and
+                        z1 != particle_init_coords[2])
+        
+    def test_z_bias_6(self):
+        """Check z-axis bias singleton score - particle outside max_r does not move"""
+        
+        # setup parameters
+        particle_radius=1
+        z_bias_k = 10.0
+        z_bias_z = 0
+        z_bias_max_r = 5
+        boxw= 20
+        particle_init_coords = [10, 10, 15]
+        
+        x, y, z = optimize_particle_z_bias(particle_radius, z_bias_k, z_bias_z, z_bias_max_r, boxw, particle_init_coords)
+        self.assertTrue(x == particle_init_coords[0] and
+                        y == particle_init_coords[1] and
+                        z == particle_init_coords[2])
+        
+        
 if __name__ == '__main__':
     IMP.test.main()


### PR DESCRIPTION
Hi, I am a student in Raveh Lab.
I made the following changes:

- added parameters k_z_bias_z and k_z_bias_max_t_ns to protobuf
- ZBiasSingletonScore: added z of xy plane to bias towards / against (relevant only if k is non-zero)
- Change ZBiasSingletonScore creation in SimulationData::create_floaters to include new z parameter, and only occur if time valid
- Added new tests for z bias
